### PR TITLE
fix: programmatic opening

### DIFF
--- a/src/lib/vaul/components/root.svelte
+++ b/src/lib/vaul/components/root.svelte
@@ -25,7 +25,7 @@
 	export let dismissible: $$Props["dismissible"] = undefined;
 
 	const {
-		states: { keyboardIsOpen, activeSnapPoint: localActiveSnapPoint, drawerId, openDrawerIds },
+		states: { keyboardIsOpen, activeSnapPoint: localActiveSnapPoint, drawerId, openDrawerIds, isOpen },
 		methods: { closeDrawer, openDrawer },
 		options: { dismissible: localDismissible },
 		updateOption
@@ -75,6 +75,9 @@
 	$: updateOption("openFocus", openFocus);
 	$: updateOption("shouldScaleBackground", shouldScaleBackground);
 	$: updateOption("dismissible", dismissible);
+
+	$: open && !$isOpen && openDrawer()
+	$: !open && $isOpen && closeDrawer()
 </script>
 
 <DialogPrimitive.Root


### PR DESCRIPTION
When opening the drawer via `bind:open` a nasty bug prevents the animation from running.

This is a workaround made in a sleepless night