### PR TITLE
feat: add `backgroundColor` prop to `<Drawer.Root />`

### DIFF
--- a/.changeset/five-ties-laugh.md
+++ b/.changeset/five-ties-laugh.md
@@ -1,0 +1,5 @@
+---
+"vaul-svelte": minor
+---
+
+feat: added `backgroundColor` prop to `<Drawer.Root />` that can be used to customize the body's background color when the drawer is open and `shouldScaleBackground` is `true`

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Additional props:
 
 `fadeFromIndex`: Index of a `snapPoint` from which the overlay fade should be applied. Defaults to the last snap point.
 
+`backgroundColor`: Background color of the body when the drawer is open and `shouldScaleBackground` is true. Defaults to black.
+
 ### Trigger
 
 The button that opens the dialog. [Props](https://www.bits-ui.com/docs/components/dialog#trigger).

--- a/src/lib/internal/vaul.ts
+++ b/src/lib/internal/vaul.ts
@@ -53,6 +53,7 @@ export type CreateVaulProps = {
 	onOpenChange?: ChangeFn<boolean>;
 	closeThreshold?: number;
 	shouldScaleBackground?: boolean;
+	backgroundColor?: string;
 	scrollLockTimeout?: number;
 	fixed?: boolean;
 	dismissible?: boolean;
@@ -443,7 +444,7 @@ export function createVaul(props: CreateVaulProps) {
 		}
 	}
 
-	function scaleBackground(open: boolean) {
+	function scaleBackground(open: boolean, backgroundColor: string | undefined = "black") {
 		const wrapper = document.querySelector("[data-vaul-drawer-wrapper]");
 
 		if (!wrapper || !get(shouldScaleBackground)) return;
@@ -452,7 +453,7 @@ export function createVaul(props: CreateVaulProps) {
 			set(
 				document.body,
 				{
-					background: "black"
+					background: backgroundColor
 				},
 				true
 			);
@@ -718,7 +719,7 @@ export function createVaul(props: CreateVaulProps) {
 		if (!$isOpen) return;
 
 		openTime.set(new Date());
-		scaleBackground(true);
+		scaleBackground(true, props.backgroundColor);
 	});
 
 	effect([visible], ([$visible]) => {

--- a/src/lib/vaul/components/root.svelte
+++ b/src/lib/vaul/components/root.svelte
@@ -15,6 +15,7 @@
 	export let openFocus: $$Props["openFocus"] = undefined;
 	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 	export let closeOnOutsideClick: $$Props["closeOnOutsideClick"] = true;
+	export let backgroundColor: $$Props["backgroundColor"] = "black";
 	export let nested: $$Props["nested"] = false;
 	export let shouldScaleBackground: $$Props["shouldScaleBackground"] = false;
 	export let activeSnapPoint: $$Props["activeSnapPoint"] = undefined;
@@ -63,6 +64,7 @@
 		onClose,
 		onRelease,
 		shouldScaleBackground,
+		backgroundColor,
 		dismissible
 	});
 
@@ -74,6 +76,7 @@
 	$: updateOption("fadeFromIndex", fadeFromIndex);
 	$: updateOption("openFocus", openFocus);
 	$: updateOption("shouldScaleBackground", shouldScaleBackground);
+	$: updateOption("backgroundColor", backgroundColor);
 	$: updateOption("dismissible", dismissible);
 </script>
 

--- a/src/lib/vaul/components/types.ts
+++ b/src/lib/vaul/components/types.ts
@@ -79,6 +79,13 @@ export type Props = {
 	shouldScaleBackground?: CreateVaulProps["shouldScaleBackground"] & {};
 
 	/**
+	 * The background color of the body when the drawer is open and `shouldScaleBackground` is true.
+	 *
+	 * @default "black"
+	 */
+	backgroundColor?: CreateVaulProps["backgroundColor"] & {};
+
+	/**
 	 * The active snap point of the drawer. You can bind to this value to
 	 * programatically change the active snap point.
 	 */

--- a/src/routes/hero.svelte
+++ b/src/routes/hero.svelte
@@ -43,7 +43,7 @@
 			<p class="text-xl text-gray-600">Drawer component for Svelte.</p>
 		</div>
 		<div class="mt-6 flex justify-center gap-4">
-			<Drawer.Root shouldScaleBackground backgroundColor="blue">
+			<Drawer.Root shouldScaleBackground>
 				<Drawer.Trigger asChild let:builder>
 					<button
 						class="rounded-full bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"

--- a/src/routes/hero.svelte
+++ b/src/routes/hero.svelte
@@ -43,7 +43,7 @@
 			<p class="text-xl text-gray-600">Drawer component for Svelte.</p>
 		</div>
 		<div class="mt-6 flex justify-center gap-4">
-			<Drawer.Root shouldScaleBackground>
+			<Drawer.Root shouldScaleBackground backgroundColor="blue">
 				<Drawer.Trigger asChild let:builder>
 					<button
 						class="rounded-full bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"


### PR DESCRIPTION
Hey thanks for Vaul. Added an option to change the background color of the document body when the drawer is open and `shouldScaleBackground` is true. Defaults to black