### PR TITLE
Fixes closeOnOutsideClick for nested drawers

### DIFF
--- a/src/lib/vaul/components/root.svelte
+++ b/src/lib/vaul/components/root.svelte
@@ -122,12 +122,14 @@
 
 		const $openDialogIds = get(openDrawerIds);
 		const currentId = get(drawerId);
-		// Find the index of the current drawer
-		const currentIndex = $openDialogIds.indexOf(currentId);
-		// Only close if this is the topmost drawer
-		if (currentIndex === $openDialogIds.length - 1) {
-			onOpenChange?.(false);
-			closeDrawer();
+		if (currentId) {
+			// Find the index of the current drawer
+			const currentIndex = $openDialogIds.indexOf(currentId);
+			// Only close if this is the topmost drawer
+			if (currentIndex === $openDialogIds.length - 1) {
+				onOpenChange?.(false);
+				closeDrawer();
+			}
 		}
 	}}
 	{...$$restProps}

--- a/src/lib/vaul/components/root.svelte
+++ b/src/lib/vaul/components/root.svelte
@@ -119,9 +119,13 @@
 		if (!$localDismissible) {
 			return;
 		}
+
 		const $openDialogIds = get(openDrawerIds);
-		const isLast = $openDialogIds[$openDialogIds.length - 1] === get(drawerId);
-		if (isLast) {
+		const currentId = get(drawerId);
+		// Find the index of the current drawer
+		const currentIndex = $openDialogIds.indexOf(currentId);
+		// Only close if this is the topmost drawer
+		if (currentIndex === $openDialogIds.length - 1) {
 			onOpenChange?.(false);
 			closeDrawer();
 		}


### PR DESCRIPTION
Improves the logic for handling nested drawer closures by using explicit index checking instead of direct ID comparison. This ensures only the topmost drawer closes when clicking outside, while maintaining parent drawers in their open state.

```diff
- const isLast = $openDialogIds[$openDialogIds.length - 1] === get(drawerId);
+ const currentIndex = $openDialogIds.indexOf(currentId);
+ if (currentIndex === $openDialogIds.length - 1) {
```

Fixes #74