### PR TITLE
fix: Expose `TriggerProps`

### DIFF
--- a/.changeset/five-lizards-beam.md
+++ b/.changeset/five-lizards-beam.md
@@ -1,0 +1,5 @@
+---
+"vaul-svelte": patch
+---
+
+fix: Expose `TriggerProps`

--- a/packages/vaul-svelte/src/lib/components/drawer/index.ts
+++ b/packages/vaul-svelte/src/lib/components/drawer/index.ts
@@ -21,4 +21,5 @@ export type {
 	DrawerDescriptionProps as DescriptionProps,
 	DrawerCloseProps as CloseProps,
 	DrawerPortalProps as PortalProps,
+	DrawerTriggerProps as TriggerProps,
 } from "./types.js";


### PR DESCRIPTION
Working on the v4 updates for `shadcn-svelte` and we need this for the re-export to add the slot attributes.